### PR TITLE
Make MemberNamesCheck fix issues

### DIFF
--- a/aliceO2/MemberNamesCheck.cpp
+++ b/aliceO2/MemberNamesCheck.cpp
@@ -12,6 +12,7 @@
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include <iostream>
 #include <regex>
+#include <string>
 
 using namespace clang::ast_matchers;
 
@@ -22,7 +23,15 @@ namespace aliceO2 {
 void MemberNamesCheck::registerMatchers(MatchFinder *Finder) {
   // Our policy says that only class members need to start with m, not
   // struct members
-  Finder->addMatcher((fieldDecl(hasParent(recordDecl(isClass())))).bind("field_decl1"), this);
+  auto o2PatchableMember = matchesName("::[a-z][A-Z][^:]*$");
+  auto o2InvalidMember = matchesName("::[^m][A-Z][^:]*$");
+  auto namingRules = allOf(o2PatchableMember,o2InvalidMember);
+  auto isAClass = hasParent(recordDecl(isClass()));
+  auto field = fieldDecl(allOf(isAClass, namingRules));
+  auto initialisers = forEachConstructorInitializer(cxxCtorInitializer(forField(field)).bind("member_initialiser1"));
+  Finder->addMatcher(field.bind("field_decl1"), this);
+  Finder->addMatcher(memberExpr(hasDeclaration(field)).bind("member_decl1"), this);
+  Finder->addMatcher(cxxConstructorDecl(forEachConstructorInitializer(allOf(cxxCtorInitializer(isMemberInitializer()).bind("member_initialiser1"), forField(field)))), this);
 }
 
 void MemberNamesCheck::check(const MatchFinder::MatchResult &Result) {
@@ -35,14 +44,53 @@ void MemberNamesCheck::check(const MatchFinder::MatchResult &Result) {
         && (MatchedDecl->getQualifiedNameAsString().find("o2::") != 0))
       return;
 
-    if (std::regex_match(MatchedDecl->getNameAsString(), Regex)) {
-      return;
-    }
-
+    std::string newName(MatchedDecl->getNameAsString());
+    newName[0] = 'm';
     diag(MatchedDecl->getLocation(),
          "field declaration %0 does not match naming rule",
          DiagnosticIDs::Error)
-        << MatchedDecl;
+        << MatchedDecl
+        << FixItHint::CreateReplacement(MatchedDecl->getLocation(), newName);
+  }
+  const auto *MatchedValue = Result.Nodes.getNodeAs<MemberExpr>("member_decl1");
+  if (MatchedValue) {
+    const auto *MatchedValueDecl = MatchedValue->getMemberDecl();
+    // check that we are inside the AliceO2 namespace to exlude system stuff
+    // FIXME: needs to be configurable
+    // NOTE: AliceO2:: is the old one. We agreed to use o2::
+
+    if ((MatchedValueDecl->getQualifiedNameAsString().find("AliceO2::") != 0)
+        && (MatchedValueDecl->getQualifiedNameAsString().find("o2::") != 0))
+      return;
+
+    std::string newName(MatchedValueDecl->getNameAsString());
+    newName[0] = 'm';
+    diag(MatchedValue->getMemberLoc(),
+         "field reference %0 does not match naming rule",
+         DiagnosticIDs::Error)
+        << MatchedValueDecl
+        << FixItHint::CreateReplacement(MatchedValue->getMemberLoc(), newName);
+  }
+  const auto *MatchedInitializer = Result.Nodes.getNodeAs<CXXCtorInitializer>("member_initialiser1");
+  if (MatchedInitializer) {
+    if (!MatchedInitializer->isWritten())
+      return;
+    const auto *MatchedValueDecl = MatchedInitializer->getMember();
+    // check that we are inside the AliceO2 namespace to exlude system stuff
+    // FIXME: needs to be configurable
+    // NOTE: AliceO2:: is the old one. We agreed to use o2::
+
+    if ((MatchedValueDecl->getQualifiedNameAsString().find("AliceO2::") != 0)
+        && (MatchedValueDecl->getQualifiedNameAsString().find("o2::") != 0))
+      return;
+
+    std::string newName(MatchedValueDecl->getNameAsString());
+    newName[0] = 'm';
+    diag(MatchedInitializer->getMemberLocation(),
+         "initialiser %0 does not match naming rule",
+         DiagnosticIDs::Error)
+        << MatchedValueDecl
+        << FixItHint::CreateReplacement(MatchedInitializer->getMemberLocation(), newName);
   }
 }
 


### PR DESCRIPTION
While limiting (for now) the kind naming convention violations to those
which are in the form "[a-z]Something", this will also provide fixup
information so that we can actually cleanup the issue, not only report
it.

Exercise to actually:

- Check and fix all member names called "Something".
- Check and fix all member names calles "m_something".

left to the reader. ;-)