### PR TITLE
Adding way to provide config options to checks

### DIFF
--- a/add_new_check.py
+++ b/add_new_check.py
@@ -86,6 +86,8 @@ public:
       : ClangTidyCheck(Name, Context) {}
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  
+  void logNameError(SourceLocation Loc, std::string name);
 };
 
 } // namespace %(module)s
@@ -141,6 +143,12 @@ void %(check_name)s::check(const MatchFinder::MatchResult &Result) {
   diag(MatchedDecl->getLocation(), "function %%0 is insufficiently awesome")
       << MatchedDecl
       << FixItHint::CreateInsertion(MatchedDecl->getLocation(), "awesome_");
+}
+
+void %(check_name)s::logNameError(SourceLocation Loc, std::string errorName)
+{
+  diag(Loc, "Could not fix \'%0\'", DiagnosticIDs::Level::Error)
+      << errorName;
 }
 
 } // namespace %(module)s


### PR DESCRIPTION
The **configs/** directory is now scanned for config options that can be provided to concrete checks.

Now when the check dumps an error instead of a warning, the part of code that made the error is logged in a file configs/"<check_name>" in format `{key: _<check_name>_._<error_code>_ value: <provide-fix-for-key>}`.

When the checker founds certain code that it thinks is problematic it tries to fix it. If the checker cannot fix it, it will consult the config-options how to correct the issue. If no such way is described in the config-options an error is dumped.