### PR TITLE
Adding new check for type names naming

### DIFF
--- a/aliceO2/AliceO2TidyModule.cpp
+++ b/aliceO2/AliceO2TidyModule.cpp
@@ -13,6 +13,7 @@
 #include "MemberNamesCheck.h"
 #include "NamespaceNamingCheck.h"
 #include "SizeofCheck.h"
+#include "TypeNamesNamingCheck.h"
 
 namespace clang {
 namespace tidy {
@@ -27,6 +28,8 @@ public:
         "aliceO2-namespace-naming");
     CheckFactories.registerCheck<SizeofCheck>(
         "aliceO2-SizeOf");
+    CheckFactories.registerCheck<TypeNamesNamingCheck>(
+        "aliceO2-type-names-naming");
   }
 };
 

--- a/aliceO2/CMakeLists.txt
+++ b/aliceO2/CMakeLists.txt
@@ -5,6 +5,7 @@ add_clang_library(clangTidyAliceO2Module
   MemberNamesCheck.cpp
   NamespaceNamingCheck.cpp
   SizeofCheck.cpp
+  TypeNamesNamingCheck.cpp
 
   LINK_LIBS
   clangAST

--- a/aliceO2/TypeNamesNamingCheck.cpp
+++ b/aliceO2/TypeNamesNamingCheck.cpp
@@ -1,0 +1,235 @@
+//===--- TypeNamesNamingCheck.cpp - clang-tidy-----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeNamesNamingCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include <regex>
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace aliceO2 {
+
+const std::string VALID_NAME_REGEX = "([A-Z][a-z]+)+[0-9]*";
+
+void TypeNamesNamingCheck::registerMatchers(MatchFinder *Finder) {
+  const auto validNameMatch = matchesName( std::string("::") + VALID_NAME_REGEX + "$" );
+
+  // match class, struct or enum declarations
+  Finder->addMatcher(decl(allOf(
+    anyOf(
+      // match class or struct declaration
+      // "hasDescendant(cxxRecordDecl())" prevents from matching implicit declarations
+      cxxRecordDecl(hasDescendant(cxxRecordDecl())),
+      enumDecl()),
+    namedDecl(unless(validNameMatch))
+    )).bind("record-enum-decl"), this );
+  
+  // match typedef statements, filtering the implicit ones that are added by the compiler
+  Finder->addMatcher( typedefDecl(unless(isImplicit())).bind("typedef-decl"), this );
+  Finder->addMatcher( usingDecl(unless(validNameMatch)).bind("using-decl"), this );
+  
+  // match usage of class or struct, filtering the implicit ones
+  Finder->addMatcher(loc(recordType(allOf(
+    hasDeclaration(unless(isImplicit())),
+    hasDeclaration(cxxRecordDecl(unless(validNameMatch)))
+    ))).bind("record-enum-usage"), this);
+    
+  // match usage of enums, filtering the implicit ones
+  Finder->addMatcher(loc(enumType(allOf(
+    hasDeclaration(unless(isImplicit())),
+    hasDeclaration(enumDecl(unless(validNameMatch)))
+    ))).bind("record-enum-usage"), this);
+
+  // match usage of typedefs, filtering the implicit ones
+  Finder->addMatcher(loc(typedefType(allOf(
+    hasDeclaration(unless(isImplicit())),
+    hasDeclaration(typedefDecl(unless(validNameMatch)))
+    ))).bind("typedef-usage"), this);
+}
+
+void TypeNamesNamingCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedRecordEnumDecl = Result.Nodes.getNodeAs<Decl>("record-enum-decl");
+  if( MatchedRecordEnumDecl )
+  {
+    std::string oldName("");
+    std::string newName("");
+    const auto *RecordDeclType = static_cast<const CXXRecordDecl*>(MatchedRecordEnumDecl);
+    if( RecordDeclType )
+    {
+      oldName = RecordDeclType->getDeclName().getAsString();
+    }
+    const auto *EnumDeclType = static_cast<const EnumDecl*>(MatchedRecordEnumDecl);
+    if( EnumDeclType )
+    {
+      oldName = EnumDeclType->getDeclName().getAsString();
+    }
+    newName = oldName;
+    
+    bool fixed = fixName(newName);
+    if( fixed && (newName != oldName) )
+    {
+      diag(MatchedRecordEnumDecl->getLocation(), "typename \'%0\' does not follow the camel case naming convention")
+          << oldName
+          << FixItHint::CreateReplacement(MatchedRecordEnumDecl->getLocation(), newName);
+
+      // fix ctors namings
+      if( RecordDeclType )
+      {
+        if( RecordDeclType->hasUserDeclaredConstructor() )
+        {
+          CXXRecordDecl::ctor_iterator it = RecordDeclType->ctor_begin();
+          for(; it != RecordDeclType->ctor_end(); ++it)
+          {
+            if( it->isImplicit() )
+              continue;
+          
+            auto ctor = *it;
+            diag(ctor->getLocation(), "constructor for typename \'%0\' does not follow the camel case naming convention")
+                << oldName
+                << FixItHint::CreateReplacement(ctor->getLocation(), newName);
+          }
+        }
+      }
+    }
+    else if( !fixed )
+    {
+      logNameError(MatchedRecordEnumDecl->getLocation(), oldName);
+    }    
+  }
+
+  const auto *MatchedTypedefDecl = Result.Nodes.getNodeAs<TypedefDecl>("typedef-decl");
+  if( MatchedTypedefDecl )
+  {
+    std::string oldName = MatchedTypedefDecl->getDeclName().getAsString();
+    std::string newName = oldName;
+    
+    if( std::regex_match(oldName, std::regex(VALID_NAME_REGEX)) )
+    {
+      return;
+    }
+    
+    bool fixed = fixName(newName);
+    if( fixed && (newName != oldName) )
+    {
+      diag(MatchedTypedefDecl->getLocation(), "typename \'%0\' does not follow the camel case naming convention")
+          << oldName
+          << FixItHint::CreateReplacement(MatchedTypedefDecl->getLocation(), newName);
+    }
+    else if( !fixed )
+    {
+      logNameError(MatchedTypedefDecl->getLocation(), oldName);
+    }
+  }
+  
+  const auto *MatchedUsingDecl = Result.Nodes.getNodeAs<UsingDecl>("using-decl");
+  if( MatchedUsingDecl )
+  {
+    std::string oldName = MatchedUsingDecl->getNameAsString();
+    std::string newName = oldName;
+    
+    bool fixed = fixName(newName);
+    if( fixed && (newName != oldName) )
+    {
+      diag(MatchedUsingDecl->getLocation(), "typename \'%0\' does not follow the camel case naming convention")
+          << oldName
+          << FixItHint::CreateReplacement(MatchedUsingDecl->getLocation(), newName);
+    }
+    else if( !fixed )
+    {
+      logNameError(MatchedUsingDecl->getLocation(), oldName);
+    }
+  }
+  
+  const auto *MatchedRecordEnumTypeLoc = Result.Nodes.getNodeAs<TypeLoc>("record-enum-usage");
+  if( MatchedRecordEnumTypeLoc )
+  {
+    const auto Type = MatchedRecordEnumTypeLoc->getType().split().asPair().first;
+    std::string oldName = Type->getAsTagDecl()->getNameAsString();    
+    std::string newName = oldName;
+    
+    bool fixed = fixName(newName);
+    if( fixed && (newName != oldName) )
+    {
+      diag(MatchedRecordEnumTypeLoc->getBeginLoc(), "typename \'%0\' does not follow the camel case naming convention")
+          << oldName
+          << FixItHint::CreateReplacement(MatchedRecordEnumTypeLoc->getSourceRange(), newName);
+    }
+    else if( !fixed )
+    {
+      logNameError(MatchedRecordEnumTypeLoc->getBeginLoc(), oldName);
+    }
+  }
+
+  const auto *MatchedTypedefTypeLoc = Result.Nodes.getNodeAs<TypeLoc>("typedef-usage");
+  if( MatchedTypedefTypeLoc )
+  {
+    const auto Type = MatchedTypedefTypeLoc->getType();
+    std::string oldName = Type->getAs<TypedefType>()->getDecl()->getNameAsString();
+    std::string newName = oldName;
+    
+    bool fixed = fixName(newName);
+    if( fixed && (newName != oldName) )
+    {
+      diag(MatchedTypedefTypeLoc->getBeginLoc(), "typename \'%0\' does not follow the camel case naming convention")
+          << oldName
+          << FixItHint::CreateReplacement(MatchedTypedefTypeLoc->getSourceRange(), newName);
+    }
+    else if( !fixed )
+    {
+      logNameError(MatchedTypedefTypeLoc->getBeginLoc(), oldName);
+    }
+  }
+}
+
+/// This function modifies the input string to one of the following ways:
+/// - Into a CamelCase string.
+/// - Into a string that is specified in the config options.
+///
+/// return: Returns true if the input string is succesfully modified,
+///         If neither of the modifying options succeeds false is returned.
+bool TypeNamesNamingCheck::fixName(std::string &name)
+{
+  std::string replace_option = Options.get(name, "");
+  if( replace_option != "" )
+  {
+    name = replace_option;
+    return true;
+  }
+  
+  if( islower(name[0]) )
+  {
+    name[0] = toupper(name[0]);
+  }
+  for(int i = 1;i < name.size();i++)
+  {
+    if( name[i] == '_' ) {
+      if( i < name.size() - 1 )
+      {
+        name[i + 1] = toupper(name[i + 1]);
+      }
+      name.erase(i, 1); // delete '_'
+    }
+  }
+  
+  return std::regex_match( name, std::regex(VALID_NAME_REGEX) );
+}
+
+void TypeNamesNamingCheck::logNameError(SourceLocation Loc, std::string errorName)
+{
+  diag(Loc, "Could not fix \'%0\'", DiagnosticIDs::Level::Error)
+      << errorName;
+}
+
+
+} // namespace aliceO2
+} // namespace tidy
+} // namespace clang

--- a/aliceO2/TypeNamesNamingCheck.h
+++ b/aliceO2/TypeNamesNamingCheck.h
@@ -1,0 +1,38 @@
+//===--- TypeNamesNamingCheck.h - clang-tidy---------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ALICEO2_TYPE_NAMES_NAMING_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ALICEO2_TYPE_NAMES_NAMING_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace aliceO2 {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/aliceO2-type-names-naming.html
+class TypeNamesNamingCheck : public ClangTidyCheck {
+public:
+  TypeNamesNamingCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  
+  bool fixName(std::string &name);
+  void logNameError(SourceLocation Loc, std::string name);
+};
+
+} // namespace aliceO2
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ALICEO2_TYPE_NAMES_NAMING_H

--- a/configs/aliceO2-type-names-naming
+++ b/configs/aliceO2-type-names-naming
@@ -1,0 +1,1 @@
+{key: aliceO2-type-names-naming.SSQ, value: SSQ}

--- a/docs/clang-tidy/checks/aliceO2-type-names-naming.rst
+++ b/docs/clang-tidy/checks/aliceO2-type-names-naming.rst
@@ -1,0 +1,24 @@
+.. title:: clang-tidy - aliceO2-type-names-naming
+
+aliceO2-type-names-naming
+=========================
+
+Type names follow camel case convention and start with an upper case letter: MyClass, MyEnum.
+
+Description:
+
+The names of all types — classes, structs, typedefs, and enums — have the same naming convention. For example:
+
+// classes and structs
+class UrlTable 
+{ ...
+class UrlTableTester 
+{ ...
+struct UrlTableProperties 
+{ ...
+
+// typedefs
+typedef HashMap<UrlTableProperties *, string> PropertiesMap;
+
+// enums
+enum UrlTableErrors { ...

--- a/docs/clang-tidy/checks/list.rst
+++ b/docs/clang-tidy/checks/list.rst
@@ -7,3 +7,4 @@ Clang-Tidy Checks
    aliceO2-MemberNamesCheck
    aliceO2-SizeofCheck
    aliceO2-namespace-naming
+   aliceO2-type-names-naming

--- a/test/aliceO2-type-names-naming.cpp
+++ b/test/aliceO2-type-names-naming.cpp
@@ -1,0 +1,348 @@
+// RUN: %check_clang_tidy %s aliceO2-type-names-naming %t
+
+class Circle
+{
+public:
+  int a;
+};
+
+class square
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: typename 'square' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}class Square{{$}}
+{
+public:
+  int a;
+};
+
+class SSQ
+{
+};
+
+SSQ abcd;
+
+class abird
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: typename 'abird' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}class Abird{{$}}
+{
+};
+
+Circle a;
+square b;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: typename 'square' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}Square b;{{$}}
+
+// Declarations
+class FirstClassNameCorrect
+{
+public:
+  int a1;
+  class FirstClassNameInnerCorrect
+  {
+  public:
+    int a2;
+  };
+  class FirstClassNameInner_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: typename 'FirstClassNameInner_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  class FirstClassNameInnerWrong{{$}}
+  {
+  public:
+    int a2;
+  };
+  
+  struct FirstClassNameInner_struct_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  struct FirstClassNameInnerStructWrong{{$}}
+  {
+    int a3;
+    static int a4;
+
+    // ctor
+    FirstClassNameInner_struct_wrong(int a = 6)
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: constructor for typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}    FirstClassNameInnerStructWrong(int a = 6){{$}}
+    {
+      this->a3 = a;
+    }
+    
+    ~FirstClassNameInner_struct_wrong()
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}    ~FirstClassNameInnerStructWrong(){{$}}
+    {
+    }
+    
+    enum Inner_Enum_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: typename 'Inner_Enum_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}    enum InnerEnumWrong{{$}}
+    {
+      enum1e1 = 0,
+      enum1e2 = 1,
+      enum1eMax = 2
+    };
+    
+    class FirstClassNameInner_struct_wrong_ClassWrong
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'FirstClassNameInner_struct_wrong_ClassWrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}    class FirstClassNameInnerStructWrongClassWrong{{$}}
+    {
+    public:
+      static int a5;
+    };
+  };
+  
+  static FirstClassNameInner_struct_wrong a3;
+// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  static FirstClassNameInnerStructWrong a3;{{$}}
+  FirstClassNameInner_struct_wrong a31;
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameInnerStructWrong a31;{{$}}
+  
+  enum FirstClassNameInnerEnumCorrect
+  {
+    enum2e1 = 0,
+    enum2e2 = 1,
+    enum2eMax = 2
+  };
+  enum First_Class_Name_Inner_Enum_Wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: typename 'First_Class_Name_Inner_Enum_Wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  enum FirstClassNameInnerEnumWrong{{$}}
+  {
+    enum3e1 = 0,
+    enum3e2 = 1,
+    enum3eMax = 2
+  };
+
+  typedef FirstClassNameInnerCorrect CorrectTypedefOfClass;
+  typedef FirstClassNameInnerCorrect wrong_typedef_of_class;
+// CHECK-MESSAGES: :[[@LINE-1]]:38: warning: typename 'wrong_typedef_of_class' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerCorrect WrongTypedefOfClass;{{$}}
+  typedef FirstClassNameInner_struct_wrong CorrectTypedefOfStruct;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerStructWrong CorrectTypedefOfStruct;{{$}}
+  typedef FirstClassNameInner_struct_wrong wrong_typedef_Of_Struct;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:44: warning: typename 'wrong_typedef_Of_Struct' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerStructWrong WrongTypedefOfStruct;{{$}}
+  typedef First_Class_Name_Inner_Enum_Wrong CorrectTypedefOfEnum;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'First_Class_Name_Inner_Enum_Wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerEnumWrong CorrectTypedefOfEnum;{{$}}
+  typedef First_Class_Name_Inner_Enum_Wrong wrongTypedefOfEnum;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'First_Class_Name_Inner_Enum_Wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:45: warning: typename 'wrongTypedefOfEnum' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerEnumWrong WrongTypedefOfEnum;{{$}}
+  typedef FirstClassNameInner_struct_wrong::Inner_Enum_wrong wrongTypedefOfInnerEnum;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:45: warning: typename 'Inner_Enum_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-3]]:62: warning: typename 'wrongTypedefOfInnerEnum' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerStructWrong::InnerEnumWrong WrongTypedefOfInnerEnum;{{$}}
+  typedef FirstClassNameInner_wrong wrongTypedefOfInnerEnum223;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: typename 'FirstClassNameInner_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:37: warning: typename 'wrongTypedefOfInnerEnum223' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameInnerWrong WrongTypedefOfInnerEnum223;{{$}}
+  
+  void f()
+  {
+    FirstClassNameInnerCorrect varClass1;
+    CorrectTypedefOfClass varClass2;
+    wrong_typedef_of_class varClass3;
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: typename 'wrong_typedef_of_class' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}    WrongTypedefOfClass varClass3;{{$}}
+    
+    CorrectTypedefOfStruct varStruct1;
+    wrong_typedef_Of_Struct varStruct2;
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: typename 'wrong_typedef_Of_Struct' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}    WrongTypedefOfStruct varStruct2;{{$}}
+  }
+};
+
+  typedef FirstClassNameCorrect::FirstClassNameInner_wrong wrongTypedefOfInnerEnum22;
+// CHECK-MESSAGES: :[[@LINE-1]]:34: warning: typename 'FirstClassNameInner_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:60: warning: typename 'wrongTypedefOfInnerEnum22' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameCorrect::FirstClassNameInnerWrong WrongTypedefOfInnerEnum22;{{$}}
+  typedef FirstClassNameCorrect::FirstClassNameInner_struct_wrong::FirstClassNameInner_struct_wrong_ClassWrong wrongTypedefOfInnerEnum222;
+// CHECK-MESSAGES: :[[@LINE-1]]:34: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:68: warning: typename 'FirstClassNameInner_struct_wrong_ClassWrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-3]]:112: warning: typename 'wrongTypedefOfInnerEnum222' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  typedef FirstClassNameCorrect::FirstClassNameInnerStructWrong::FirstClassNameInnerStructWrongClassWrong WrongTypedefOfInnerEnum222;{{$}}
+
+void dummy1(int a) {}
+
+void dummy2(FirstClassNameCorrect::FirstClassNameInner_struct_wrong var) {}
+// CHECK-MESSAGES: :[[@LINE-1]]:36: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}void dummy2(FirstClassNameCorrect::FirstClassNameInnerStructWrong var) {}{{$}}
+
+
+namespace just_a_namespace
+{
+  class NamespaceClassCorrect
+  {
+  public:
+    int a;
+  };
+  class NamespaceClass_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: typename 'NamespaceClass_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  class NamespaceClassWrong{{$}}
+  {
+  public:
+    int a;
+  };
+  
+  struct NamespaceStructCorrect
+  {
+  public:
+    int a;
+  };
+  struct NamespaceStruct_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: typename 'NamespaceStruct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  struct NamespaceStructWrong{{$}}
+  {
+  public:
+    int a;
+    int unique_var_name;
+  };
+  
+  union NamespaceUnionCorrect
+  {
+    int a;
+    int b;
+  };
+  union NamespaceUnion_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: typename 'NamespaceUnion_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  union NamespaceUnionWrong{{$}}
+  {
+    int a;
+    int b;
+  };
+
+  enum NamespaceEnumCorrect
+  {
+    ns_enum_c_1 = 0,
+    ns_enum_c_2 = 1,
+    ns_enum_c_MAX = 2
+  };
+  enum NamespaceEnum_wrong
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: typename 'NamespaceEnum_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  enum NamespaceEnumWrong{{$}}
+  {
+    ns_enum_w_1 = 0,
+    ns_enum_w_2 = 1,
+    ns_enum_w_MAX = 2
+  };
+};
+
+just_a_namespace::NamespaceClass_wrong ns_var_1;
+// CHECK-MESSAGES: :[[@LINE-1]]:19: warning: typename 'NamespaceClass_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}just_a_namespace::NamespaceClassWrong ns_var_1;{{$}}
+just_a_namespace::NamespaceStruct_wrong ns_var_2;
+// CHECK-MESSAGES: :[[@LINE-1]]:19: warning: typename 'NamespaceStruct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}just_a_namespace::NamespaceStructWrong ns_var_2;{{$}}
+just_a_namespace::NamespaceUnion_wrong ns_var_3;
+// CHECK-MESSAGES: :[[@LINE-1]]:19: warning: typename 'NamespaceUnion_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}just_a_namespace::NamespaceUnionWrong ns_var_3;{{$}}
+just_a_namespace::NamespaceEnum_wrong ns_var_4;
+// CHECK-MESSAGES: :[[@LINE-1]]:19: warning: typename 'NamespaceEnum_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}just_a_namespace::NamespaceEnumWrong ns_var_4;{{$}}
+
+using namespace just_a_namespace;
+
+NamespaceClass_wrong ns_var_5;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: typename 'NamespaceClass_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}NamespaceClassWrong ns_var_5;{{$}}
+NamespaceStruct_wrong ns_var_6;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: typename 'NamespaceStruct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}NamespaceStructWrong ns_var_6;{{$}}
+NamespaceUnion_wrong ns_var_7;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: typename 'NamespaceUnion_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}NamespaceUnionWrong ns_var_7;{{$}}
+NamespaceEnum_wrong ns_var_8;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: typename 'NamespaceEnum_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}NamespaceEnumWrong ns_var_8;{{$}}
+
+using just_a_namespace::NamespaceStruct_wrong;
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: typename 'NamespaceStruct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}using just_a_namespace::NamespaceStructWrong;{{$}}
+
+int main()
+{
+  // Definitions
+  FirstClassNameCorrect varClass1;
+  
+  FirstClassNameCorrect::FirstClassNameInnerCorrect varClassInner1;
+  FirstClassNameCorrect::FirstClassNameInner_struct_wrong varStructInner1;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerStructWrong varStructInner1;{{$}}
+  FirstClassNameCorrect::FirstClassNameInner_struct_wrong varStructInner2(5);
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerStructWrong varStructInner2(5);{{$}}
+
+  FirstClassNameCorrect::FirstClassNameInner_struct_wrong::Inner_Enum_wrong varEnum1;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:60: warning: typename 'Inner_Enum_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerStructWrong::InnerEnumWrong varEnum1;{{$}}
+  FirstClassNameCorrect::First_Class_Name_Inner_Enum_Wrong varEnum2;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'First_Class_Name_Inner_Enum_Wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerEnumWrong varEnum2;{{$}}
+  FirstClassNameCorrect::FirstClassNameInnerEnumCorrect varEnum3;
+
+  FirstClassNameCorrect::CorrectTypedefOfClass varTypedef1;
+  FirstClassNameCorrect::wrong_typedef_of_class varTypedef2;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'wrong_typedef_of_class' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::WrongTypedefOfClass varTypedef2;{{$}}
+  FirstClassNameCorrect::CorrectTypedefOfStruct varTypedef3;
+  FirstClassNameCorrect::wrong_typedef_Of_Struct varTypedef4;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'wrong_typedef_Of_Struct' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::WrongTypedefOfStruct varTypedef4;{{$}}
+  FirstClassNameCorrect::CorrectTypedefOfEnum varTypedef5;
+  FirstClassNameCorrect::wrongTypedefOfEnum varTypedef6;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'wrongTypedefOfEnum' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::WrongTypedefOfEnum varTypedef6;{{$}}
+  FirstClassNameCorrect::wrongTypedefOfInnerEnum varTypedef7;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'wrongTypedefOfInnerEnum' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::WrongTypedefOfInnerEnum varTypedef7;{{$}}
+  
+  // Usages
+  FirstClassNameCorrect::FirstClassNameInner_struct_wrong::a4 = 5;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerStructWrong::a4 = 5;{{$}}
+  dummy1(FirstClassNameCorrect::FirstClassNameInner_struct_wrong::a4);
+// CHECK-MESSAGES: :[[@LINE-1]]:33: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  dummy1(FirstClassNameCorrect::FirstClassNameInnerStructWrong::a4);{{$}}
+  
+  FirstClassNameCorrect::FirstClassNameInner_struct_wrong::FirstClassNameInner_struct_wrong_ClassWrong::a5 = 6;
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:60: warning: typename 'FirstClassNameInner_struct_wrong_ClassWrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerStructWrong::FirstClassNameInnerStructWrongClassWrong::a5 = 6;{{$}}
+  dummy1(FirstClassNameCorrect::FirstClassNameInner_struct_wrong::FirstClassNameInner_struct_wrong_ClassWrong::a5);
+// CHECK-MESSAGES: :[[@LINE-1]]:33: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:67: warning: typename 'FirstClassNameInner_struct_wrong_ClassWrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  dummy1(FirstClassNameCorrect::FirstClassNameInnerStructWrong::FirstClassNameInnerStructWrongClassWrong::a5);{{$}}
+  
+  dummy2( FirstClassNameCorrect::FirstClassNameInner_struct_wrong(5) );
+// CHECK-MESSAGES: :[[@LINE-1]]:34: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  dummy2( FirstClassNameCorrect::FirstClassNameInnerStructWrong(5) );{{$}}
+  FirstClassNameCorrect::FirstClassNameInner_struct_wrong temp1 = FirstClassNameCorrect::FirstClassNameInner_struct_wrong(6);
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-MESSAGES: :[[@LINE-2]]:90: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}  FirstClassNameCorrect::FirstClassNameInnerStructWrong temp1 = FirstClassNameCorrect::FirstClassNameInnerStructWrong(6);{{$}}
+  
+  return 0;
+}
+
+
+class temp_struct
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: typename 'temp_struct' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}class TempStruct{{$}}
+{
+int a;
+};
+
+FirstClassNameCorrect::FirstClassNameInner_struct_wrong one;
+// CHECK-MESSAGES: :[[@LINE-1]]:24: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}FirstClassNameCorrect::FirstClassNameInnerStructWrong one;{{$}}
+static FirstClassNameCorrect::FirstClassNameInner_struct_wrong two;
+// CHECK-MESSAGES: :[[@LINE-1]]:31: warning: typename 'FirstClassNameInner_struct_wrong' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}static FirstClassNameCorrect::FirstClassNameInnerStructWrong two;{{$}}
+temp_struct three;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: typename 'temp_struct' does not follow the camel case naming convention [aliceO2-type-names-naming]
+// CHECK-FIXES: {{^}}TempStruct three;{{$}}
+
+
+


### PR DESCRIPTION
This checker checks declarations and usages of `class`, `struct`, `enum`, `union` and `typedef`.