### PR TITLE
Modify check namespace naming. Add check configuration option.

### DIFF
--- a/aliceO2/NamespaceNamingCheck.cpp
+++ b/aliceO2/NamespaceNamingCheck.cpp
@@ -29,7 +29,8 @@ NamespaceNamingCheck::NamespaceNamingCheck(StringRef Name, ClangTidyContext *Con
   VALID_PATH_REGEX = Options.getLocalOrGlobal("CheckPathRegex","");
 	if( VALID_PATH_REGEX == "" )
 	{
-	  fprintf(stderr,"Error: User must provide a .clang-tidy file in any of the parent directories of the source files containing a key-value pair for key \'CheckPathRegex\'");
+	  fprintf(stderr,"Error: User must provide a .clang-tidy file in any of the parent directories of the source files containing a key-value pair for key \'CheckPathRegex\' "
+	                        "or pass the key-value pair with the command line argument --config");
 	  exit(1);
 	}
 }

--- a/aliceO2/NamespaceNamingCheck.cpp
+++ b/aliceO2/NamespaceNamingCheck.cpp
@@ -13,15 +13,26 @@
 #include <regex>
 #include <string>
 #include <ctype.h>
- 
+
 using namespace clang::ast_matchers;
 
 namespace clang {
 namespace tidy {
 namespace aliceO2 {
- 
+
 const std::string VALID_NAME_REGEX = "[a-z][a-z_0-9]+";
-const std::string VALID_PATH_REGEX = "(.*/O2/.*)|(.*/test/.*)";
+std::string VALID_PATH_REGEX = "";
+
+NamespaceNamingCheck::NamespaceNamingCheck(StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context)
+{
+  VALID_PATH_REGEX = Options.getLocalOrGlobal("CheckPathRegex","");
+	if( VALID_PATH_REGEX == "" )
+	{
+	  fprintf(stderr,"Error: User must provide a .clang-tidy file in any of the parent directories of the source files containing a key-value pair for key \'CheckPathRegex\'");
+	  exit(1);
+	}
+}
 
 bool isOutsideOfTargetScope(std::string filename)
 {
@@ -30,7 +41,7 @@ bool isOutsideOfTargetScope(std::string filename)
 
 void NamespaceNamingCheck::registerMatchers(MatchFinder *Finder) {
   const auto validNameMatch = matchesName( std::string("::") + VALID_NAME_REGEX + "$" );
-  
+
   // matches namespace declarations that have invalid name
   Finder->addMatcher(namespaceDecl(allOf(
     unless(validNameMatch),
@@ -52,16 +63,22 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
     {
       return;
     }
-  
+
     std::string newName(MatchedNamespaceDecl->getDeclName().getAsString());
-    
-    fixNamespaceName(newName);
-    
-    diag(MatchedNamespaceDecl->getLocation(), "namespace %0 does not follow the underscore convention")
+    std::string oldName=newName;
+
+    if(fixNamespaceName(newName))
+    {
+      diag(MatchedNamespaceDecl->getLocation(), "namespace %0 does not follow the underscore convention")
         << MatchedNamespaceDecl
         << FixItHint::CreateReplacement(MatchedNamespaceDecl->getLocation(), newName);
+    }
+    else
+    {
+      logNameError(MatchedNamespaceDecl->getLocation(), oldName);
+    }
   }
-  
+
   const auto *MatchedNamespaceLoc = Result.Nodes.getNodeAs<NestedNameSpecifierLoc>("namespace-usage");
   if( MatchedNamespaceLoc )
   {
@@ -71,12 +88,18 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
       return;
     }
     std::string newName(AsNamespace->getDeclName().getAsString());
-    
-    fixNamespaceName(newName);
-    
-    diag(MatchedNamespaceLoc->getLocalBeginLoc(), "namespace %0 does not follow the underscore convention")
+    std::string oldName=newName;
+
+    if(fixNamespaceName(newName))
+    {
+      diag(MatchedNamespaceLoc->getLocalBeginLoc(), "namespace %0 does not follow the underscore convention")
         << AsNamespace
         << FixItHint::CreateReplacement(MatchedNamespaceLoc->getLocalBeginLoc(), newName);
+    }
+    else
+    {
+      logNameError(MatchedNamespaceLoc->getLocalBeginLoc(), oldName);
+    }
   }
 
   const auto *MatchedUsingNamespace = Result.Nodes.getNodeAs<UsingDirectiveDecl>("using-namespace");
@@ -86,24 +109,37 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
     {
       return;
     }
-    
+
     std::string newName(MatchedUsingNamespace->getNominatedNamespace()->getDeclName().getAsString());
-    
+    std::string oldName=newName;
+
     if( std::regex_match(newName, std::regex(VALID_NAME_REGEX)) )
     {
       return;
     }
-    
-    fixNamespaceName(newName);
-    
-    diag(MatchedUsingNamespace->getLocation(), "namespace %0 does not follow the underscore convention")
+
+    if(fixNamespaceName(newName))
+    {
+      diag(MatchedUsingNamespace->getLocation(), "namespace %0 does not follow the underscore convention")
         << MatchedUsingNamespace->getNominatedNamespace()
         << FixItHint::CreateReplacement(MatchedUsingNamespace->getLocation(), newName);
+    }
+    else
+    {
+      logNameError(MatchedNamespaceDecl->getLocation(), oldName);
+    }
   }
 }
 
-void NamespaceNamingCheck::fixNamespaceName(std::string &name)
+bool NamespaceNamingCheck::fixNamespaceName(std::string &name)
 {
+  std::string replace_option = Options.get(name, "");
+  if( replace_option != "" )
+  {
+    name = replace_option;
+    return true;
+  }
+
   for(int i=name.size()-1; i>=0; i--) {
     if(isupper(name[i])) {
       if(i != 0 && islower(name[i-1])) {
@@ -113,6 +149,14 @@ void NamespaceNamingCheck::fixNamespaceName(std::string &name)
       name[i] = tolower(name[i]);
     }
   }
+
+  return std::regex_match( name, std::regex(VALID_NAME_REGEX) );
+}
+
+void NamespaceNamingCheck::logNameError(SourceLocation Loc, std::string errorName)
+{
+  diag(Loc, "Could not fix \'%0\'", DiagnosticIDs::Level::Error)
+      << errorName;
 }
 
 } // namespace aliceO2

--- a/aliceO2/NamespaceNamingCheck.cpp
+++ b/aliceO2/NamespaceNamingCheck.cpp
@@ -13,31 +13,46 @@
 #include <regex>
 #include <string>
 #include <ctype.h>
-
+ 
 using namespace clang::ast_matchers;
 
 namespace clang {
 namespace tidy {
 namespace aliceO2 {
+ 
+const std::string VALID_NAME_REGEX = "[a-z][a-z_0-9]+";
+const std::string VALID_PATH_REGEX = "(.*/O2/.*)|(.*/test/.*)";
 
-const std::string VALID_NAME_REGEX = "([a-z]+_)*[a-z]+";
+bool isOutsideOfTargetScope(std::string filename)
+{
+  return !std::regex_match(filename, std::regex(VALID_PATH_REGEX));
+}
 
 void NamespaceNamingCheck::registerMatchers(MatchFinder *Finder) {
   const auto validNameMatch = matchesName( std::string("::") + VALID_NAME_REGEX + "$" );
   
   // matches namespace declarations that have invalid name
-  Finder->addMatcher(namespaceDecl( unless( validNameMatch ) ).bind("namespace-decl"), this);
+  Finder->addMatcher(namespaceDecl(allOf(
+    unless(validNameMatch),
+    unless(isAnonymous())
+    )).bind("namespace-decl"), this);
   // matches usage of namespace
-  Finder->addMatcher(nestedNameSpecifierLoc(loc(nestedNameSpecifier(specifiesNamespace(
-    unless( validNameMatch ) )))).bind("namespace-usage"), this );
+  Finder->addMatcher(nestedNameSpecifierLoc(loc(nestedNameSpecifier(specifiesNamespace(unless(validNameMatch)
+    )))).bind("namespace-usage"), this );
   // matches "using namespace" declarations
-  Finder->addMatcher(usingDirectiveDecl().bind("using-namespace"), this);
+  Finder->addMatcher(usingDirectiveDecl(unless(isImplicit()
+    )).bind("using-namespace"), this);
 }
 
 void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *MatchedNamespaceDecl = Result.Nodes.getNodeAs<NamespaceDecl>("namespace-decl");
   if( MatchedNamespaceDecl )
   {
+    if( isOutsideOfTargetScope( Result.SourceManager->getFilename(MatchedNamespaceDecl->getLocation()).str() ) )
+    {
+      return;
+    }
+  
     std::string newName(MatchedNamespaceDecl->getDeclName().getAsString());
     
     fixNamespaceName(newName);
@@ -51,6 +66,10 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
   if( MatchedNamespaceLoc )
   {
     const auto *AsNamespace = MatchedNamespaceLoc->getNestedNameSpecifier()->getAsNamespace();
+    if( isOutsideOfTargetScope( Result.SourceManager->getFilename(AsNamespace->getLocation()).str() ) )
+    {
+      return;
+    }
     std::string newName(AsNamespace->getDeclName().getAsString());
     
     fixNamespaceName(newName);
@@ -63,6 +82,11 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *MatchedUsingNamespace = Result.Nodes.getNodeAs<UsingDirectiveDecl>("using-namespace");
   if( MatchedUsingNamespace )
   {
+    if( isOutsideOfTargetScope( Result.SourceManager->getFilename(MatchedUsingNamespace->getNominatedNamespace()->getLocation()).str() ) )
+    {
+      return;
+    }
+    
     std::string newName(MatchedUsingNamespace->getNominatedNamespace()->getDeclName().getAsString());
     
     if( std::regex_match(newName, std::regex(VALID_NAME_REGEX)) )
@@ -80,9 +104,9 @@ void NamespaceNamingCheck::check(const MatchFinder::MatchResult &Result) {
 
 void NamespaceNamingCheck::fixNamespaceName(std::string &name)
 {
-  for(int i=0; i<name.size(); i++) {
+  for(int i=name.size()-1; i>=0; i--) {
     if(isupper(name[i])) {
-      if(i != 0 && name[i-1] != '_') {
+      if(i != 0 && islower(name[i-1])) {
         name.insert(i, "_");
         i++;
       }

--- a/aliceO2/NamespaceNamingCheck.h
+++ b/aliceO2/NamespaceNamingCheck.h
@@ -22,12 +22,12 @@ namespace aliceO2 {
 /// http://clang.llvm.org/extra/clang-tidy/checks/aliceO2-namespace-naming.html
 class NamespaceNamingCheck : public ClangTidyCheck {
 public:
-  NamespaceNamingCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  NamespaceNamingCheck(StringRef Name, ClangTidyContext *Context);
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   
-  void fixNamespaceName(std::string &name);
+  bool fixNamespaceName(std::string &name);
+  void logNameError(SourceLocation Loc, std::string errorName);
 };
 
 } // namespace aliceO2

--- a/check_clang_tidy.py
+++ b/check_clang_tidy.py
@@ -111,6 +111,10 @@ def main():
   except subprocess.CalledProcessError as e:
     diff_output = e.output
 
+  if has_check_messages:
+    messages_file = temp_file_name + '.msg'
+    write_file(messages_file, clang_tidy_output)
+
   print('------------------------------ Fixes -----------------------------\n' +
         diff_output.decode() +
         '\n------------------------------------------------------------------')
@@ -126,8 +130,6 @@ def main():
       raise
 
   if has_check_messages:
-    messages_file = temp_file_name + '.msg'
-    write_file(messages_file, clang_tidy_output)
     try:
       subprocess.check_output(
           ['FileCheck', '-input-file=' + messages_file, input_file_name,

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,3 @@
+CheckOptions:
+  - key: CheckPathRegex
+    value: '.*/test/.*'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,9 @@ find_program(LLVMFILECHECK FileCheck HINTS PATH)
 if (LLVMFILECHECK)
 
 # testing namespace naming checker
-  add_test(NAME aliceo2namespace COMMAND
-                ${CMAKE_SOURCE_DIR}/check_clang_tidy.py
-                ${CMAKE_SOURCE_DIR}/test/aliceO2-namespace-naming.cpp
+  add_test(NAME aliceo2namespace COMMAND 
+                ${CMAKE_SOURCE_DIR}/check_clang_tidy.py 
+                ${CMAKE_SOURCE_DIR}/test/aliceO2-namespace-naming.cpp 
                 aliceO2-namespace-naming ${CMAKE_BINARY_DIR}/tool/O2codecheck)
 
 else()

--- a/test/aliceO2-namespace-naming.cpp
+++ b/test/aliceO2-namespace-naming.cpp
@@ -1,5 +1,35 @@
 // RUN: %check_clang_tidy %s aliceO2-namespace-naming %t
 
+namespace {}
+namespace{
+}
+namespace
+{
+namespace simple
+{
+};
+};
+
+namespace o2
+{
+}
+namespace o2codecheck
+{
+}
+namespace a_1234_5678_b
+{
+}
+
+namespace TPC
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: namespace 'TPC' does not follow the underscore convention [aliceO2-namespace-naming]
+// CHECK-FIXES: {{^}}namespace tpc{{$}}
+{
+}
+
+using namespace TPC;
+// CHECK-MESSAGES: :[[@LINE-1]]:17: warning: namespace 'TPC' does not follow the underscore convention [aliceO2-namespace-naming]
+// CHECK-FIXES: {{^}}using namespace tpc;{{$}}
+
 namespace OuterNamespaceWrong
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: namespace 'OuterNamespaceWrong' does not follow the underscore convention [aliceO2-namespace-naming]
 // CHECK-FIXES: {{^}}namespace outer_namespace_wrong{{$}}


### PR DESCRIPTION
Now the checks could be configured to check only those files whos path matches the regular expression provided in a `.clang-tidy` file.
The `.clang-tidy` file must be located at the same or any parent folder of the files being targeted for check (For instance, it could be placed in the main source directory of a project). The file content must be like:

CheckOptions:
  \- key: **CheckPathRegex**
  value: '_SOME_REGEX_'

An example file is the `.clang_tidy` in the `O2CodeChecker/test/` folder. The tool `run_O2codechecker.py` is used the same as before.