### PR TITLE
Bump to Clang 11

### DIFF
--- a/ClangTidy.h
+++ b/ClangTidy.h
@@ -9,19 +9,22 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDY_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDY_H
 
-#include "ClangTidyCheck.h"
 #include "ClangTidyDiagnosticConsumer.h"
 #include "ClangTidyOptions.h"
-#include "llvm/Support/raw_ostream.h"
 #include <memory>
 #include <vector>
 
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
+
 namespace clang {
 
+class ASTConsumer;
 class CompilerInstance;
 namespace tooling {
 class CompilationDatabase;
-}
+} // namespace tooling
 
 namespace tidy {
 
@@ -33,14 +36,14 @@ public:
       ClangTidyContext &Context,
       IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS = nullptr);
 
-  /// \brief Returns an ASTConsumer that runs the specified clang-tidy checks.
+  /// Returns an ASTConsumer that runs the specified clang-tidy checks.
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &Compiler, StringRef File);
 
-  /// \brief Get the list of enabled checks.
+  /// Get the list of enabled checks.
   std::vector<std::string> getCheckNames();
 
-  /// \brief Get the union of options from all checks.
+  /// Get the union of options from all checks.
   ClangTidyOptions::OptionMap getCheckOptions();
 
 private:
@@ -49,12 +52,12 @@ private:
   std::unique_ptr<ClangTidyCheckFactories> CheckFactories;
 };
 
-/// \brief Fills the list of check names that are enabled when the provided
+/// Fills the list of check names that are enabled when the provided
 /// filters are applied.
 std::vector<std::string> getCheckNames(const ClangTidyOptions &Options,
                                        bool AllowEnablingAnalyzerAlphaCheckers);
 
-/// \brief Returns the effective check-specific options.
+/// Returns the effective check-specific options.
 ///
 /// The method configures ClangTidy with the specified \p Options and collects
 /// effective options from all created checks. The returned set of options
@@ -64,7 +67,7 @@ ClangTidyOptions::OptionMap
 getCheckOptions(const ClangTidyOptions &Options,
                 bool AllowEnablingAnalyzerAlphaCheckers);
 
-/// \brief Run a set of clang-tidy checks on a set of files.
+/// Run a set of clang-tidy checks on a set of files.
 ///
 /// \param EnableCheckProfile If provided, it enables check profile collection
 /// in MatchFinder, and will contain the result of the profile.
@@ -82,7 +85,7 @@ runClangTidy(clang::tidy::ClangTidyContext &Context,
 // FIXME: This interface will need to be significantly extended to be useful.
 // FIXME: Implement confidence levels for displaying/fixing errors.
 //
-/// \brief Displays the found \p Errors to the users. If \p Fix is true, \p
+/// Displays the found \p Errors to the users. If \p Fix is true, \p
 /// Errors containing fixes are automatically applied and reformatted. If no
 /// clang-format configuration file is found, the given \P FormatStyle is used.
 void handleErrors(llvm::ArrayRef<ClangTidyError> Errors,
@@ -90,7 +93,7 @@ void handleErrors(llvm::ArrayRef<ClangTidyError> Errors,
                   unsigned &WarningsAsErrorsCount,
                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS);
 
-/// \brief Serializes replacements into YAML and writes them to the specified
+/// Serializes replacements into YAML and writes them to the specified
 /// output stream.
 void exportReplacements(StringRef MainFilePath,
                         const std::vector<ClangTidyError> &Errors,

--- a/ClangTidyCheck.h
+++ b/ClangTidyCheck.h
@@ -13,19 +13,86 @@
 #include "ClangTidyOptions.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/SourceManager.h"
-#include "llvm/ADT/StringExtras.h"
-#include <memory>
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/Error.h"
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace clang {
 
 class CompilerInstance;
+class SourceManager;
 
 namespace tidy {
 
-/// \brief Base class for all clang-tidy checks.
+/// This class should be specialized by any enum type that needs to be converted
+/// to and from an \ref llvm::StringRef.
+template <class T> struct OptionEnumMapping {
+  // Specializations of this struct must implement this function.
+  static ArrayRef<std::pair<T, StringRef>> getEnumMapping() = delete;
+};
+
+template <typename T> class OptionError : public llvm::ErrorInfo<T> {
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+
+public:
+  void log(raw_ostream &OS) const override { OS << this->message(); }
+};
+
+class MissingOptionError : public OptionError<MissingOptionError> {
+public:
+  explicit MissingOptionError(std::string OptionName)
+      : OptionName(OptionName) {}
+
+  std::string message() const override;
+  static char ID;
+private:
+  const std::string OptionName;
+};
+
+class UnparseableEnumOptionError
+    : public OptionError<UnparseableEnumOptionError> {
+public:
+  explicit UnparseableEnumOptionError(std::string LookupName,
+                                      std::string LookupValue)
+      : LookupName(LookupName), LookupValue(LookupValue) {}
+  explicit UnparseableEnumOptionError(std::string LookupName,
+                                      std::string LookupValue,
+                                      std::string SuggestedValue)
+      : LookupName(LookupName), LookupValue(LookupValue),
+        SuggestedValue(SuggestedValue) {}
+
+  std::string message() const override;
+  static char ID;
+
+private:
+  const std::string LookupName;
+  const std::string LookupValue;
+  const llvm::Optional<std::string> SuggestedValue;
+};
+
+class UnparseableIntegerOptionError
+    : public OptionError<UnparseableIntegerOptionError> {
+public:
+  explicit UnparseableIntegerOptionError(std::string LookupName,
+                                         std::string LookupValue,
+                                         bool IsBoolean = false)
+      : LookupName(LookupName), LookupValue(LookupValue), IsBoolean(IsBoolean) {
+  }
+
+  std::string message() const override;
+  static char ID;
+
+private:
+  const std::string LookupName;
+  const std::string LookupValue;
+  const bool IsBoolean;
+};
+
+/// Base class for all clang-tidy checks.
 ///
 /// To implement a ``ClangTidyCheck``, write a subclass and override some of the
 /// base class's methods. E.g. to implement a check that validates namespace
@@ -46,17 +113,30 @@ namespace tidy {
 /// useful/necessary.
 class ClangTidyCheck : public ast_matchers::MatchFinder::MatchCallback {
 public:
-  /// \brief Initializes the check with \p CheckName and \p Context.
+  /// Initializes the check with \p CheckName and \p Context.
   ///
   /// Derived classes must implement the constructor with this signature or
   /// delegate it. If a check needs to read options, it can do this in the
   /// constructor using the Options.get() methods below.
   ClangTidyCheck(StringRef CheckName, ClangTidyContext *Context);
 
-  /// \brief Override this to register ``PPCallbacks`` in the preprocessor.
+  /// Override this to disable registering matchers and PP callbacks if an
+  /// invalid language version is being used.
+  ///
+  /// For example if a check is examining overloaded functions then this should
+  /// be overridden to return false when the CPlusPlus flag is not set in
+  /// \p LangOpts.
+  virtual bool isLanguageVersionSupported(const LangOptions &LangOpts) const {
+    return true;
+  }
+
+  /// Override this to register ``PPCallbacks`` in the preprocessor.
   ///
   /// This should be used for clang-tidy checks that analyze preprocessor-
   /// dependent properties, e.g. include directives and macro definitions.
+  ///
+  /// This will only be executed if the function isLanguageVersionSupported
+  /// returns true.
   ///
   /// There are two Preprocessors to choose from that differ in how they handle
   /// modular #includes:
@@ -71,7 +151,7 @@ public:
   virtual void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                                    Preprocessor *ModuleExpanderPP) {}
 
-  /// \brief Override this to register AST matchers with \p Finder.
+  /// Override this to register AST matchers with \p Finder.
   ///
   /// This should be used by clang-tidy checks that analyze code properties that
   /// dependent on AST knowledge.
@@ -80,96 +160,303 @@ public:
   /// "this" will be used as callback, but you can also specify other callback
   /// classes. Thereby, different matchers can trigger different callbacks.
   ///
+  /// This will only be executed if the function isLanguageVersionSupported
+  /// returns true.
+  ///
   /// If you need to merge information between the different matchers, you can
   /// store these as members of the derived class. However, note that all
   /// matches occur in the order of the AST traversal.
   virtual void registerMatchers(ast_matchers::MatchFinder *Finder) {}
 
-  /// \brief ``ClangTidyChecks`` that register ASTMatchers should do the actual
+  /// ``ClangTidyChecks`` that register ASTMatchers should do the actual
   /// work in here.
   virtual void check(const ast_matchers::MatchFinder::MatchResult &Result) {}
 
-  /// \brief Add a diagnostic with the check's name.
+  /// Add a diagnostic with the check's name.
   DiagnosticBuilder diag(SourceLocation Loc, StringRef Description,
                          DiagnosticIDs::Level Level = DiagnosticIDs::Warning);
 
-  /// \brief Should store all options supported by this check with their
+  /// Should store all options supported by this check with their
   /// current values or default values for options that haven't been overridden.
   ///
   /// The check should use ``Options.store()`` to store each option it supports
   /// whether it has the default value or it has been overridden.
   virtual void storeOptions(ClangTidyOptions::OptionMap &Options) {}
 
-  /// \brief Provides access to the ``ClangTidyCheck`` options via check-local
+  /// Provides access to the ``ClangTidyCheck`` options via check-local
   /// names.
   ///
   /// Methods of this class prepend ``CheckName + "."`` to translate check-local
   /// option names to global option names.
   class OptionsView {
   public:
-    /// \brief Initializes the instance using \p CheckName + "." as a prefix.
+    /// Initializes the instance using \p CheckName + "." as a prefix.
     OptionsView(StringRef CheckName,
                 const ClangTidyOptions::OptionMap &CheckOptions);
 
-    /// \brief Read a named option from the ``Context``.
+    /// Read a named option from the ``Context``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from the
+    /// ``CheckOptions``. If the corresponding key is not present, returns
+    /// a ``MissingOptionError``.
+    llvm::Expected<std::string> get(StringRef LocalName) const;
+
+    /// Read a named option from the ``Context``.
     ///
     /// Reads the option with the check-local name \p LocalName from the
     /// ``CheckOptions``. If the corresponding key is not present, returns
     /// \p Default.
-    std::string get(StringRef LocalName, StringRef Default) const;
-
-    /// \brief Read a named option from the ``Context``.
-    ///
-    /// Reads the option with the check-local name \p LocalName from local or
-    /// global ``CheckOptions``. Gets local option first. If local is not
-    /// present, falls back to get global option. If global option is not
-    /// present either, returns Default.
-    std::string getLocalOrGlobal(StringRef LocalName, StringRef Default) const;
-
-    /// \brief Read a named option from the ``Context`` and parse it as an
-    /// integral type ``T``.
-    ///
-    /// Reads the option with the check-local name \p LocalName from the
-    /// ``CheckOptions``. If the corresponding key is not present, returns
-    /// \p Default.
-    template <typename T>
-    typename std::enable_if<std::is_integral<T>::value, T>::type
-    get(StringRef LocalName, T Default) const {
-      std::string Value = get(LocalName, "");
-      T Result = Default;
-      if (!Value.empty())
-        StringRef(Value).getAsInteger(10, Result);
-      return Result;
+    std::string get(StringRef LocalName, StringRef Default) const {
+      if (llvm::Expected<std::string> Val = get(LocalName))
+        return *Val;
+      else
+        llvm::consumeError(Val.takeError());
+      return Default.str();
     }
 
-    /// \brief Read a named option from the ``Context`` and parse it as an
+    /// Read a named option from the ``Context``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from local or
+    /// global ``CheckOptions``. Gets local option first. If local is not
+    /// present, falls back to get global option. If global option is not
+    /// present either, returns a ``MissingOptionError``.
+    llvm::Expected<std::string> getLocalOrGlobal(StringRef LocalName) const;
+
+    /// Read a named option from the ``Context``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from local or
+    /// global ``CheckOptions``. Gets local option first. If local is not
+    /// present, falls back to get global option. If global option is not
+    /// present either, returns \p Default.
+    std::string getLocalOrGlobal(StringRef LocalName, StringRef Default) const {
+      if (llvm::Expected<std::string> Val = getLocalOrGlobal(LocalName))
+        return *Val;
+      else
+        llvm::consumeError(Val.takeError());
+      return Default.str();
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
+    /// integral type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from the
+    /// ``CheckOptions``. If the corresponding key is not present, returns
+    /// a ``MissingOptionError``. If the corresponding key can't be parsed as
+    /// a ``T``, return an ``UnparseableIntegerOptionError``.
+    template <typename T>
+    std::enable_if_t<std::is_integral<T>::value, llvm::Expected<T>>
+    get(StringRef LocalName) const {
+      if (llvm::Expected<std::string> Value = get(LocalName)) {
+        T Result{};
+        if (!StringRef(*Value).getAsInteger(10, Result))
+          return Result;
+        return llvm::make_error<UnparseableIntegerOptionError>(
+            (NamePrefix + LocalName).str(), *Value);
+      } else
+        return std::move(Value.takeError());
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
+    /// integral type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from the
+    /// ``CheckOptions``. If the corresponding key is not present or it can't be
+    /// parsed as a ``T``, returns \p Default.
+    template <typename T>
+    std::enable_if_t<std::is_integral<T>::value, T> get(StringRef LocalName,
+                                                        T Default) const {
+      if (llvm::Expected<T> ValueOr = get<T>(LocalName))
+        return *ValueOr;
+      else
+        logErrToStdErr(ValueOr.takeError());
+      return Default;
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
     /// integral type ``T``.
     ///
     /// Reads the option with the check-local name \p LocalName from local or
     /// global ``CheckOptions``. Gets local option first. If local is not
     /// present, falls back to get global option. If global option is not
-    /// present either, returns Default.
+    /// present either, returns a ``MissingOptionError``. If the corresponding
+    /// key can't be parsed as a ``T``, return an
+    /// ``UnparseableIntegerOptionError``.
     template <typename T>
-    typename std::enable_if<std::is_integral<T>::value, T>::type
+    std::enable_if_t<std::is_integral<T>::value, llvm::Expected<T>>
+    getLocalOrGlobal(StringRef LocalName) const {
+      llvm::Expected<std::string> ValueOr = get(LocalName);
+      bool IsGlobal = false;
+      if (!ValueOr) {
+        IsGlobal = true;
+        llvm::consumeError(ValueOr.takeError());
+        ValueOr = getLocalOrGlobal(LocalName);
+        if (!ValueOr)
+          return std::move(ValueOr.takeError());
+      }
+      T Result{};
+      if (!StringRef(*ValueOr).getAsInteger(10, Result))
+        return Result;
+      return llvm::make_error<UnparseableIntegerOptionError>(
+          (IsGlobal ? LocalName.str() : (NamePrefix + LocalName).str()),
+          *ValueOr);
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
+    /// integral type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from local or
+    /// global ``CheckOptions``. Gets local option first. If local is not
+    /// present, falls back to get global option. If global option is not
+    /// present either or it can't be parsed as a ``T``, returns \p Default.
+    template <typename T>
+    std::enable_if_t<std::is_integral<T>::value, T>
     getLocalOrGlobal(StringRef LocalName, T Default) const {
-      std::string Value = getLocalOrGlobal(LocalName, "");
-      T Result = Default;
-      if (!Value.empty())
-        StringRef(Value).getAsInteger(10, Result);
-      return Result;
+      if (llvm::Expected<T> ValueOr = getLocalOrGlobal<T>(LocalName))
+        return *ValueOr;
+      else
+        logErrToStdErr(ValueOr.takeError());
+      return Default;
     }
 
-    /// \brief Stores an option with the check-local name \p LocalName with
+    /// Read a named option from the ``Context`` and parse it as an
+    /// enum type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from the
+    /// ``CheckOptions``. If the corresponding key is not present, returns a
+    /// ``MissingOptionError``. If the key can't be parsed as a ``T`` returns a
+    /// ``UnparseableEnumOptionError``.
+    ///
+    /// \ref clang::tidy::OptionEnumMapping must be specialized for ``T`` to
+    /// supply the mapping required to convert between ``T`` and a string.
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value, llvm::Expected<T>>
+    get(StringRef LocalName, bool IgnoreCase = false) {
+      if (llvm::Expected<int64_t> ValueOr =
+              getEnumInt(LocalName, typeEraseMapping<T>(), false, IgnoreCase))
+        return static_cast<T>(*ValueOr);
+      else
+        return std::move(ValueOr.takeError());
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
+    /// enum type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from the
+    /// ``CheckOptions``. If the corresponding key is not present or it can't be
+    /// parsed as a ``T``, returns \p Default.
+    ///
+    /// \ref clang::tidy::OptionEnumMapping must be specialized for ``T`` to
+    /// supply the mapping required to convert between ``T`` and a string.
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value, T>
+    get(StringRef LocalName, T Default, bool IgnoreCase = false) {
+      if (auto ValueOr = get<T>(LocalName, IgnoreCase))
+        return *ValueOr;
+      else
+        logErrToStdErr(ValueOr.takeError());
+      return Default;
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
+    /// enum type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from local or
+    /// global ``CheckOptions``. Gets local option first. If local is not
+    /// present, falls back to get global option. If global option is not
+    /// present either, returns a ``MissingOptionError``. If the key can't be
+    /// parsed as a ``T`` returns a ``UnparseableEnumOptionError``.
+    ///
+    /// \ref clang::tidy::OptionEnumMapping must be specialized for ``T`` to
+    /// supply the mapping required to convert between ``T`` and a string.
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value, llvm::Expected<T>>
+    getLocalOrGlobal(StringRef LocalName,
+                     bool IgnoreCase = false) {
+      if (llvm::Expected<int64_t> ValueOr =
+              getEnumInt(LocalName, typeEraseMapping<T>(), true, IgnoreCase))
+        return static_cast<T>(*ValueOr);
+      else
+        return std::move(ValueOr.takeError());
+    }
+
+    /// Read a named option from the ``Context`` and parse it as an
+    /// enum type ``T``.
+    ///
+    /// Reads the option with the check-local name \p LocalName from local or
+    /// global ``CheckOptions``. Gets local option first. If local is not
+    /// present, falls back to get global option. If global option is not
+    /// present either or it can't be parsed as a ``T``, returns \p Default.
+    ///
+    /// \ref clang::tidy::OptionEnumMapping must be specialized for ``T`` to
+    /// supply the mapping required to convert between ``T`` and a string.
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value, T>
+    getLocalOrGlobal(StringRef LocalName, T Default, bool IgnoreCase = false) {
+      if (auto ValueOr = getLocalOrGlobal<T>(LocalName, IgnoreCase))
+        return *ValueOr;
+      else
+        logErrToStdErr(ValueOr.takeError());
+      return Default;
+    }
+
+    /// Stores an option with the check-local name \p LocalName with
     /// string value \p Value to \p Options.
     void store(ClangTidyOptions::OptionMap &Options, StringRef LocalName,
                StringRef Value) const;
 
-    /// \brief Stores an option with the check-local name \p LocalName with
-    /// ``int64_t`` value \p Value to \p Options.
-    void store(ClangTidyOptions::OptionMap &Options, StringRef LocalName,
-               int64_t Value) const;
+    /// Stores an option with the check-local name \p LocalName with
+    /// integer value \p Value to \p Options.
+    template <typename T>
+    std::enable_if_t<std::is_integral<T>::value>
+    store(ClangTidyOptions::OptionMap &Options, StringRef LocalName,
+          T Value) const {
+      storeInt(Options, LocalName, Value);
+    }
+
+    /// Stores an option with the check-local name \p LocalName as the string
+    /// representation of the Enum \p Value to \p Options.
+    ///
+    /// \ref clang::tidy::OptionEnumMapping must be specialized for ``T`` to
+    /// supply the mapping required to convert between ``T`` and a string.
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value>
+    store(ClangTidyOptions::OptionMap &Options, StringRef LocalName, T Value) {
+      ArrayRef<std::pair<T, StringRef>> Mapping =
+          OptionEnumMapping<T>::getEnumMapping();
+      auto Iter = llvm::find_if(
+          Mapping, [&](const std::pair<T, StringRef> &NameAndEnum) {
+            return NameAndEnum.first == Value;
+          });
+      assert(Iter != Mapping.end() && "Unknown Case Value");
+      store(Options, LocalName, Iter->second);
+    }
 
   private:
+    using NameAndValue = std::pair<int64_t, StringRef>;
+
+    llvm::Expected<int64_t> getEnumInt(StringRef LocalName,
+                                       ArrayRef<NameAndValue> Mapping,
+                                       bool CheckGlobal, bool IgnoreCase);
+
+    template <typename T>
+    std::enable_if_t<std::is_enum<T>::value, std::vector<NameAndValue>>
+    typeEraseMapping() {
+      ArrayRef<std::pair<T, StringRef>> Mapping =
+          OptionEnumMapping<T>::getEnumMapping();
+      std::vector<NameAndValue> Result;
+      Result.reserve(Mapping.size());
+      for (auto &MappedItem : Mapping) {
+        Result.emplace_back(static_cast<int64_t>(MappedItem.first),
+                            MappedItem.second);
+      }
+      return Result;
+    }
+
+    void storeInt(ClangTidyOptions::OptionMap &Options, StringRef LocalName,
+                  int64_t Value) const;
+
+    static void logErrToStdErr(llvm::Error &&Err);
+
     std::string NamePrefix;
     const ClangTidyOptions::OptionMap &CheckOptions;
   };
@@ -182,11 +469,59 @@ private:
 
 protected:
   OptionsView Options;
-  /// \brief Returns the main file name of the current translation unit.
+  /// Returns the main file name of the current translation unit.
   StringRef getCurrentMainFile() const { return Context->getCurrentFile(); }
-  /// \brief Returns the language options from the context.
+  /// Returns the language options from the context.
   const LangOptions &getLangOpts() const { return Context->getLangOpts(); }
 };
+
+/// Read a named option from the ``Context`` and parse it as a bool.
+///
+/// Reads the option with the check-local name \p LocalName from the
+/// ``CheckOptions``. If the corresponding key is not present, returns
+/// a ``MissingOptionError``. If the corresponding key can't be parsed as
+/// a bool, return an ``UnparseableIntegerOptionError``.
+template <>
+llvm::Expected<bool>
+ClangTidyCheck::OptionsView::get<bool>(StringRef LocalName) const;
+
+/// Read a named option from the ``Context`` and parse it as a bool.
+///
+/// Reads the option with the check-local name \p LocalName from the
+/// ``CheckOptions``. If the corresponding key is not present or it can't be
+/// parsed as a bool, returns \p Default.
+template <>
+bool ClangTidyCheck::OptionsView::get<bool>(StringRef LocalName,
+                                            bool Default) const;
+
+/// Read a named option from the ``Context`` and parse it as a bool.
+///
+/// Reads the option with the check-local name \p LocalName from local or
+/// global ``CheckOptions``. Gets local option first. If local is not
+/// present, falls back to get global option. If global option is not
+/// present either, returns a ``MissingOptionError``. If the corresponding
+/// key can't be parsed as a bool, return an
+/// ``UnparseableIntegerOptionError``.
+template <>
+llvm::Expected<bool>
+ClangTidyCheck::OptionsView::getLocalOrGlobal<bool>(StringRef LocalName) const;
+
+/// Read a named option from the ``Context`` and parse it as a bool.
+///
+/// Reads the option with the check-local name \p LocalName from local or
+/// global ``CheckOptions``. Gets local option first. If local is not
+/// present, falls back to get global option. If global option is not
+/// present either or it can't be parsed as a bool, returns \p Default.
+template <>
+bool ClangTidyCheck::OptionsView::getLocalOrGlobal<bool>(StringRef LocalName,
+                                                         bool Default) const;
+
+/// Stores an option with the check-local name \p LocalName with
+/// bool value \p Value to \p Options.
+template <>
+void ClangTidyCheck::OptionsView::store<bool>(
+    ClangTidyOptions::OptionMap &Options, StringRef LocalName,
+    bool Value) const;
 
 } // namespace tidy
 } // namespace clang

--- a/ClangTidyDiagnosticConsumer.h
+++ b/ClangTidyDiagnosticConsumer.h
@@ -12,17 +12,15 @@
 #include "ClangTidyOptions.h"
 #include "ClangTidyProfiling.h"
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/SourceManager.h"
 #include "clang/Tooling/Core/Diagnostic.h"
-#include "clang/Tooling/Refactoring.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/StringMap.h"
-#include "llvm/Support/Timer.h"
+#include "llvm/Support/Regex.h"
 
 namespace clang {
 
 class ASTContext;
 class CompilerInstance;
+class SourceManager;
 namespace ast_matchers {
 class MatchFinder;
 }
@@ -44,6 +42,7 @@ struct ClangTidyError : tooling::Diagnostic {
                  bool IsWarningAsError);
 
   bool IsWarningAsError;
+  std::vector<std::string> EnabledDiagnosticAliases;
 };
 
 /// Contains displayed and ignored diagnostic counters for a ClangTidy
@@ -154,7 +153,7 @@ public:
 
   /// Should be called when starting to process new translation unit.
   void setCurrentBuildDirectory(StringRef BuildDirectory) {
-    CurrentBuildDirectory = BuildDirectory;
+    CurrentBuildDirectory = std::string(BuildDirectory);
   }
 
   /// Returns build directory of the current translation unit.
@@ -174,7 +173,8 @@ public:
     return DiagLevelAndFormatString(
         static_cast<DiagnosticIDs::Level>(
             DiagEngine->getDiagnosticLevel(DiagnosticID, Loc)),
-        DiagEngine->getDiagnosticIDs()->getDescription(DiagnosticID));
+        std::string(
+            DiagEngine->getDiagnosticIDs()->getDescription(DiagnosticID)));
   }
 
 private:
@@ -211,15 +211,12 @@ private:
 /// This does not handle suppression of notes following a suppressed diagnostic;
 /// that is left to the caller is it requires maintaining state in between calls
 /// to this function.
-/// The `CheckMacroExpansion` parameter determines whether the function should
-/// handle the case where the diagnostic is inside a macro expansion. A degree
-/// of control over this is needed because handling this case can require
-/// examining source files other than the one in which the diagnostic is
-/// located, and in some use cases we cannot rely on such other files being
-/// mapped in the SourceMapper.
+/// If `AllowIO` is false, the function does not attempt to read source files
+/// from disk which are not already mapped into memory; such files are treated
+/// as not containing a suppression comment.
 bool shouldSuppressDiagnostic(DiagnosticsEngine::Level DiagLevel,
                               const Diagnostic &Info, ClangTidyContext &Context,
-                              bool CheckMacroExpansion = true);
+                              bool AllowIO = true);
 
 /// A diagnostic consumer that turns each \c Diagnostic into a
 /// \c SourceManager-independent \c ClangTidyError.
@@ -244,6 +241,7 @@ public:
 private:
   void finalizeLastError();
   void removeIncompatibleErrors();
+  void removeDuplicatedDiagnosticsOfAliasCheckers();
 
   /// Returns the \c HeaderFilter constructed for the options set in the
   /// context.

--- a/ClangTidyForceLinker.h
+++ b/ClangTidyForceLinker.h
@@ -15,15 +15,15 @@
 namespace clang {
 namespace tidy {
 
-// This anchor is used to force the linker to link the CERTModule.
-extern volatile int CERTModuleAnchorSource;
-static int LLVM_ATTRIBUTE_UNUSED CERTModuleAnchorDestination =
-    CERTModuleAnchorSource;
-
 // This anchor is used to force the linker to link the AbseilModule.
 extern volatile int AbseilModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED AbseilModuleAnchorDestination =
     AbseilModuleAnchorSource;
+
+// This anchor is used to force the linker to link the AndroidModule.
+extern volatile int AndroidModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED AndroidModuleAnchorDestination =
+    AndroidModuleAnchorSource;
 
 // This anchor is used to force the linker to link the BoostModule.
 extern volatile int BoostModuleAnchorSource;
@@ -35,15 +35,10 @@ extern volatile int BugproneModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED BugproneModuleAnchorDestination =
     BugproneModuleAnchorSource;
 
-// This anchor is used to force the linker to link the LinuxKernelModule.
-extern volatile int LinuxKernelModuleAnchorSource;
-static int LLVM_ATTRIBUTE_UNUSED LinuxKernelModuleAnchorDestination =
-    LinuxKernelModuleAnchorSource;
-
-// This anchor is used to force the linker to link the LLVMModule.
-extern volatile int LLVMModuleAnchorSource;
-static int LLVM_ATTRIBUTE_UNUSED LLVMModuleAnchorDestination =
-    LLVMModuleAnchorSource;
+// This anchor is used to force the linker to link the CERTModule.
+extern volatile int CERTModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED CERTModuleAnchorDestination =
+    CERTModuleAnchorSource;
 
 // This anchor is used to force the linker to link the CppCoreGuidelinesModule.
 extern volatile int CppCoreGuidelinesModuleAnchorSource;
@@ -65,10 +60,25 @@ extern volatile int GoogleModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED GoogleModuleAnchorDestination =
     GoogleModuleAnchorSource;
 
-// This anchor is used to force the linker to link the AndroidModule.
-extern volatile int AndroidModuleAnchorSource;
-static int LLVM_ATTRIBUTE_UNUSED AndroidModuleAnchorDestination =
-    AndroidModuleAnchorSource;
+// This anchor is used to force the linker to link the HICPPModule.
+extern volatile int HICPPModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED HICPPModuleAnchorDestination =
+    HICPPModuleAnchorSource;
+
+// This anchor is used to force the linker to link the LinuxKernelModule.
+extern volatile int LinuxKernelModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED LinuxKernelModuleAnchorDestination =
+    LinuxKernelModuleAnchorSource;
+
+// This anchor is used to force the linker to link the LLVMModule.
+extern volatile int LLVMModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED LLVMModuleAnchorDestination =
+    LLVMModuleAnchorSource;
+
+// This anchor is used to force the linker to link the LLVMLibcModule.
+extern volatile int LLVMLibcModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED LLVMLibcModuleAnchorDestination =
+    LLVMLibcModuleAnchorSource;
 
 // This anchor is used to force the linker to link the MiscModule.
 extern volatile int MiscModuleAnchorSource;
@@ -87,6 +97,11 @@ extern volatile int MPIModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED MPIModuleAnchorDestination =
     MPIModuleAnchorSource;
 #endif
+
+// This anchor is used to force the linker to link the ObjCModule.
+extern volatile int ObjCModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED ObjCModuleAnchorDestination =
+    ObjCModuleAnchorSource;
 
 // This anchor is used to force the linker to link the OpenMPModule.
 extern volatile int OpenMPModuleAnchorSource;
@@ -107,16 +122,6 @@ static int LLVM_ATTRIBUTE_UNUSED PortabilityModuleAnchorDestination =
 extern volatile int ReadabilityModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED ReadabilityModuleAnchorDestination =
     ReadabilityModuleAnchorSource;
-
-// This anchor is used to force the linker to link the ObjCModule.
-extern volatile int ObjCModuleAnchorSource;
-static int LLVM_ATTRIBUTE_UNUSED ObjCModuleAnchorDestination =
-    ObjCModuleAnchorSource;
-
-// This anchor is used to force the linker to link the HICPPModule.
-extern volatile int HICPPModuleAnchorSource;
-static int LLVM_ATTRIBUTE_UNUSED HICPPModuleAnchorDestination =
-    HICPPModuleAnchorSource;
 
 // This anchor is used to force the linker to link the ZirconModule.
 extern volatile int ZirconModuleAnchorSource;

--- a/ClangTidyModule.h
+++ b/ClangTidyModule.h
@@ -9,16 +9,19 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDYMODULE_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDYMODULE_H
 
-#include "ClangTidy.h"
+#include "ClangTidyOptions.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include <functional>
 #include <map>
 #include <memory>
 #include <string>
-#include <utility>
 
 namespace clang {
 namespace tidy {
+
+class ClangTidyCheck;
+class ClangTidyContext;
 
 /// A collection of \c ClangTidyCheckFactory instances.
 ///
@@ -27,12 +30,12 @@ namespace tidy {
 class ClangTidyCheckFactories {
 public:
   using CheckFactory = std::function<std::unique_ptr<ClangTidyCheck>(
-      StringRef Name, ClangTidyContext *Context)>;
+      llvm::StringRef Name, ClangTidyContext *Context)>;
 
   /// Registers check \p Factory with name \p Name.
   ///
   /// For all checks that have default constructors, use \c registerCheck.
-  void registerCheckFactory(StringRef Name, CheckFactory Factory);
+  void registerCheckFactory(llvm::StringRef Name, CheckFactory Factory);
 
   /// Registers the \c CheckType with the name \p Name.
   ///
@@ -55,9 +58,9 @@ public:
   ///   }
   /// };
   /// \endcode
-  template <typename CheckType> void registerCheck(StringRef CheckName) {
+  template <typename CheckType> void registerCheck(llvm::StringRef CheckName) {
     registerCheckFactory(CheckName,
-                         [](StringRef Name, ClangTidyContext *Context) {
+                         [](llvm::StringRef Name, ClangTidyContext *Context) {
                            return std::make_unique<CheckType>(Name, Context);
                          });
   }

--- a/ClangTidyProfiling.h
+++ b/ClangTidyProfiling.h
@@ -13,10 +13,11 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Timer.h"
-#include "llvm/Support/raw_ostream.h"
 #include <string>
-#include <utility>
-#include <vector>
+
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
 
 namespace clang {
 namespace tidy {

--- a/aliceO2/MemberNamesCheck.h
+++ b/aliceO2/MemberNamesCheck.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ALICEO2_MEMBER_NAMES_H
 
 #include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
 #include <regex>
 
 namespace clang {

--- a/aliceO2/NamespaceNamingCheck.h
+++ b/aliceO2/NamespaceNamingCheck.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ALICEO2_NAMESPACE_NAMING_H
 
 #include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
 
 namespace clang {
 namespace tidy {

--- a/aliceO2/SizeofCheck.h
+++ b/aliceO2/SizeofCheck.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_ALICEO2_SIZEOF_H
 
 #include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
 
 namespace clang {
 namespace tidy {

--- a/plugin/FooCheck.h
+++ b/plugin/FooCheck.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_PLUGIN_FOO_H
 
 #include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
 
 namespace clang {
 namespace tidy {

--- a/reporting/InterfaceLister.h
+++ b/reporting/InterfaceLister.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_INTERFACELISTER_NAMES_H
 
 #include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
 
 namespace clang {
 namespace tidy {

--- a/reporting/VirtFuncLister.h
+++ b/reporting/VirtFuncLister.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_VIRTFUNCLISTER_NAMES_H
 
 #include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
 
 namespace clang {
 namespace tidy {

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(O2codecheck
   clangTidyHICPPModule
   clangTidyLinuxKernelModule
   clangTidyLLVMModule
+  clangTidyLLVMLibcModule
   clangTidyMiscModule
   clangTidyModernizeModule
   clangTidyMPIModule

--- a/tool/ClangTidyMain.cpp
+++ b/tool/ClangTidyMain.cpp
@@ -507,3 +507,7 @@ int clangTidyMain(int argc, const char **argv) {
 
 } // namespace tidy
 } // namespace clang
+
+int main(int argc, const char **argv) {
+  return clang::tidy::clangTidyMain(argc, argv);
+}

--- a/tool/ClangTidyMain.cpp
+++ b/tool/ClangTidyMain.cpp
@@ -22,9 +22,8 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/WithColor.h"
 
-using namespace clang::ast_matchers;
-using namespace clang::driver;
 using namespace clang::tooling;
 using namespace llvm;
 
@@ -35,17 +34,20 @@ static cl::extrahelp ClangTidyHelp(R"(
 Configuration files:
   clang-tidy attempts to read configuration for each source file from a
   .clang-tidy file located in the closest parent directory of the source
-  file. If any configuration options have a corresponding command-line
-  option, command-line option takes precedence. The effective
-  configuration can be inspected using -dump-config:
+  file. If InheritParentConfig is true in a config file, the configuration file
+  in the parent directory (if any exists) will be taken and current config file
+  will be applied on top of the parent one. If any configuration options have
+  a corresponding command-line option, command-line option takes precedence.
+  The effective configuration can be inspected using -dump-config:
 
     $ clang-tidy -dump-config
     ---
-    Checks:          '-*,some-check'
-    WarningsAsErrors: ''
-    HeaderFilterRegex: ''
-    FormatStyle:     none
-    User:            user
+    Checks:              '-*,some-check'
+    WarningsAsErrors:    ''
+    HeaderFilterRegex:   ''
+    FormatStyle:         none
+    InheritParentConfig: true
+    User:                user
     CheckOptions:
       - key:             some-check.SomeOption
         value:           'some value'
@@ -225,6 +227,15 @@ over the real file system.
                                        cl::value_desc("filename"),
                                        cl::cat(ClangTidyCategory));
 
+static cl::opt<bool> UseColor("use-color", cl::desc(R"(
+Use colors in diagnostics. If not set, colors
+will be used if the terminal connected to
+standard output supports colors.
+This option overrides the 'UseColor' option in
+.clang-tidy file, if any.
+)"),
+                              cl::init(false), cl::cat(ClangTidyCategory));
+
 namespace clang {
 namespace tidy {
 
@@ -287,14 +298,16 @@ static std::unique_ptr<ClangTidyOptionsProvider> createOptionsProvider(
     OverrideOptions.SystemHeaders = SystemHeaders;
   if (FormatStyle.getNumOccurrences() > 0)
     OverrideOptions.FormatStyle = FormatStyle;
+  if (UseColor.getNumOccurrences() > 0)
+    OverrideOptions.UseColor = UseColor;
 
   if (!Config.empty()) {
     if (llvm::ErrorOr<ClangTidyOptions> ParsedConfig =
             parseConfiguration(Config)) {
       return std::make_unique<ConfigOptionsProvider>(
           GlobalOptions,
-          ClangTidyOptions::getDefaults().mergeWith(DefaultOptions),
-          *ParsedConfig, OverrideOptions);
+          ClangTidyOptions::getDefaults().mergeWith(DefaultOptions, 0),
+          *ParsedConfig, OverrideOptions, std::move(FS));
     } else {
       llvm::errs() << "Error: invalid configuration specified.\n"
                    << ParsedConfig.getError().message() << "\n";
@@ -327,10 +340,16 @@ getVfsFromFile(const std::string &OverlayFile,
   return FS;
 }
 
-static int clangTidyMain(int argc, const char **argv) {
+int clangTidyMain(int argc, const char **argv) {
   llvm::InitLLVM X(argc, argv);
-  CommonOptionsParser OptionsParser(argc, argv, ClangTidyCategory,
-                                    cl::ZeroOrMore);
+  llvm::Expected<CommonOptionsParser> OptionsParser =
+      CommonOptionsParser::create(argc, argv, ClangTidyCategory,
+                                  cl::ZeroOrMore);
+  if (!OptionsParser) {
+    llvm::WithColor::error() << llvm::toString(OptionsParser.takeError());
+    return 1;
+  }
+
   llvm::IntrusiveRefCntPtr<vfs::OverlayFileSystem> BaseFS(
       new vfs::OverlayFileSystem(vfs::getRealFileSystem()));
 
@@ -361,12 +380,12 @@ static int clangTidyMain(int argc, const char **argv) {
   SmallString<256> ProfilePrefix = MakeAbsolute(StoreCheckProfile);
 
   StringRef FileName("dummy");
-  auto PathList = OptionsParser.getSourcePathList();
+  auto PathList = OptionsParser->getSourcePathList();
   if (!PathList.empty()) {
     FileName = PathList.front();
   }
 
-  SmallString<256> FilePath = MakeAbsolute(FileName);
+  SmallString<256> FilePath = MakeAbsolute(std::string(FileName));
 
   ClangTidyOptions EffectiveOptions = OptionsProvider->getOptions(FilePath);
   std::vector<std::string> EnabledChecks =
@@ -405,7 +424,7 @@ static int clangTidyMain(int argc, const char **argv) {
         getCheckOptions(EffectiveOptions, AllowEnablingAnalyzerAlphaCheckers);
     llvm::outs() << configurationAsText(
                         ClangTidyOptions::getDefaults().mergeWith(
-                            EffectiveOptions))
+                            EffectiveOptions, 0))
                  << "\n";
     return 0;
   }
@@ -429,7 +448,7 @@ static int clangTidyMain(int argc, const char **argv) {
   ClangTidyContext Context(std::move(OwningOptionsProvider),
                            AllowEnablingAnalyzerAlphaCheckers);
   std::vector<ClangTidyError> Errors =
-      runClangTidy(Context, OptionsParser.getCompilations(), PathList, BaseFS,
+      runClangTidy(Context, OptionsParser->getCompilations(), PathList, BaseFS,
                    EnableCheckProfile, ProfilePrefix);
   bool FoundErrors = llvm::find_if(Errors, [](const ClangTidyError &E) {
                        return E.DiagLevel == ClangTidyError::Error;
@@ -467,7 +486,7 @@ static int clangTidyMain(int argc, const char **argv) {
       llvm::errs() << WErrorCount << " warning" << Plural << " treated as error"
                    << Plural << "\n";
     }
-    return WErrorCount;
+    return 1;
   }
 
   if (FoundErrors) {
@@ -488,7 +507,3 @@ static int clangTidyMain(int argc, const char **argv) {
 
 } // namespace tidy
 } // namespace clang
-
-int main(int argc, const char **argv) {
-  return clang::tidy::clangTidyMain(argc, argv);
-}


### PR DESCRIPTION
This fixes the compilation of the CodeChecker with the clang 11 headers, but I could not test it locally since my local Gentoo clang installation does not build the clang libs in the default way, thus the linking fails, also with the old CodeChecker and clang 10.
So not 100% sure if this PR is complete, or if something is missing.